### PR TITLE
Resolves reset not implemented error

### DIFF
--- a/gym_trading/envs/trading_env.py
+++ b/gym_trading/envs/trading_env.py
@@ -190,7 +190,7 @@ class TradingEnv(gym.Env):
     self.action_space = spaces.Discrete( 3 )
     self.observation_space= spaces.Box( self.src.min_values,
                                         self.src.max_values)
-    self.reset()
+    self._reset()
 
   def _configure(self, display=None):
     self.display = display
@@ -224,7 +224,7 @@ class TradingEnv(gym.Env):
   
   def run_strat(self,  strategy, return_df=True):
     """run provided strategy, returns dataframe with all steps"""
-    observation = self.reset()
+    observation = self._reset()
     done = False
     while not done:
       action = strategy( observation, self ) # call strategy


### PR DESCRIPTION
Reset method is not implemented. Call interal _reset instead.

Traceback (most recent call last):
  File "/Users/pim/Projects/machine-learning/trading-gym/trading.py", line 11, in <module>
    env = gym.make('trading-v0')
  File "/Users/pim/virtualenvs/spy-predictor/lib/python3.6/site-packages/gym/envs/registration.py", line 163, in make
    return registry.make(id)
  File "/Users/pim/virtualenvs/spy-predictor/lib/python3.6/site-packages/gym/envs/registration.py", line 119, in make
    env = spec.make()
  File "/Users/plinders/virtualenvs/spy-predictor/lib/python3.6/site-packages/gym/envs/registration.py", line 86, in make
    env = cls(**self._kwargs)
  File "/Users/pim/Projects/machine-learning/trading-gym/gym_trading/envs/trading_env.py", line 202, in __init__
    self.reset()
  File "/Users/pim/virtualenvs/spy-predictor/lib/python3.6/site-packages/gym/core.py", line 71, in reset
    raise NotImplementedError
NotImplementedError